### PR TITLE
Implement regular expression for affiliate links following 'to' or 'at'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,8 +54,6 @@
       <artifactId>mockito-all</artifactId>
       <version>1.10.19</version>
       <scope>test</scope>
-      <version>4.12</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
         <groupId>com.google.auto.value</groupId>

--- a/src/main/java/com/google/step/youtube/DescriptionParser.java
+++ b/src/main/java/com/google/step/youtube/DescriptionParser.java
@@ -6,14 +6,15 @@ import java.util.regex.Pattern;
 import java.util.regex.Matcher;
 
 /**
- * Class for parsing the descriptions of YouTube videos for promotional codes and affiliate links. 
+ * Class for parsing the descriptions of YouTube videos for promotional codes
+ * and affiliate links.
  */
 public class DescriptionParser {
 
     // enum is package private in order to access in tests
     enum Patterns {
-        
-        CODE_NO_QUOTES(Pattern.compile("(?<=\\b(?i)code\\s)([A-Z0-9]{2,})")), 
+
+        CODE_NO_QUOTES(Pattern.compile("(?<=\\b(?i)code\\s)([A-Z0-9]{2,})")),
         CODE_WITH_QUOTES(Pattern.compile("(?<=\\b(?i)code\\s(\"|'))(.+?)(?=(\"|'))")),
         TO_AT_LINKS(Pattern.compile("(?<=\\b(?i)(to|at)\\s)(https*:\\/\\/)[^\\s,\\)]+"));
 
@@ -28,11 +29,12 @@ public class DescriptionParser {
         }
     }
 
-    /** 
+    /**
      * Parses the given string for promotional codes and affiliate links.
      *
      * @param description of the YouTube video to be parsed.
-     * @return A list of all promotional codes and affiliate links found in the description, duplicates allowed.
+     * @return A list of all promotional codes and affiliate links found in the
+     *         description, duplicates allowed.
      */
     public static List<String> parse(String description) {
         List<String> codes = new ArrayList<>();
@@ -43,10 +45,10 @@ public class DescriptionParser {
         return codes;
     }
 
-    /** 
+    /**
      * Finds all matches in the given string from the given regex pattern.
      *
-     * @param pattern of the regular experssion to use for matching.
+     * @param pattern     of the regular experssion to use for matching.
      * @param description of the YouTube video to be parsed.
      * @return A list of all matches found in description.
      */
@@ -59,6 +61,5 @@ public class DescriptionParser {
         }
         return matches;
     }
-  
-}
 
+}

--- a/src/main/java/com/google/step/youtube/DescriptionParser.java
+++ b/src/main/java/com/google/step/youtube/DescriptionParser.java
@@ -15,7 +15,7 @@ public class DescriptionParser {
         
         CODE_NO_QUOTES(Pattern.compile("(?<=\\b(?i)code\\s)([A-Z0-9]{2,})")), 
         CODE_WITH_QUOTES(Pattern.compile("(?<=\\b(?i)code\\s(\"|'))(.+?)(?=(\"|'))")),
-        GOTO_AT_LINKS(Pattern.compile("((?<=\\b(?i)go\\sto\\s)|(?<=\\b(?i)at\\s))(https:\\/\\/\\S+)"));
+        TO_AT_LINKS(Pattern.compile("((?<=\\b(?i)to\\s)|(?<=\\b(?i)at\\s))(https*:\\/\\/)[^\\s,\\)]+"));
 
         private final Pattern regex;
 

--- a/src/main/java/com/google/step/youtube/DescriptionParser.java
+++ b/src/main/java/com/google/step/youtube/DescriptionParser.java
@@ -14,7 +14,8 @@ public class DescriptionParser {
     enum Patterns {
         
         CODE_NO_QUOTES(Pattern.compile("(?<=\\b(?i)code\\s)([A-Z0-9]{2,})")), 
-        CODE_WITH_QUOTES(Pattern.compile("(?<=\\b(?i)code\\s(\"|'))(.+?)(?=(\"|'))"));
+        CODE_WITH_QUOTES(Pattern.compile("(?<=\\b(?i)code\\s(\"|'))(.+?)(?=(\"|'))")),
+        GOTO_AT_LINKS(Pattern.compile("((?<=\\b(?i)go\\sto\\s)|(?<=\\b(?i)at\\s))(https:\\/\\/\\S+)"));
 
         private final Pattern regex;
 

--- a/src/main/java/com/google/step/youtube/DescriptionParser.java
+++ b/src/main/java/com/google/step/youtube/DescriptionParser.java
@@ -15,7 +15,7 @@ public class DescriptionParser {
         
         CODE_NO_QUOTES(Pattern.compile("(?<=\\b(?i)code\\s)([A-Z0-9]{2,})")), 
         CODE_WITH_QUOTES(Pattern.compile("(?<=\\b(?i)code\\s(\"|'))(.+?)(?=(\"|'))")),
-        TO_AT_LINKS(Pattern.compile("((?<=\\b(?i)to\\s)|(?<=\\b(?i)at\\s))(https*:\\/\\/)[^\\s,\\)]+"));
+        TO_AT_LINKS(Pattern.compile("(?<=\\b(?i)(to|at)\\s)(https*:\\/\\/)[^\\s,\\)]+"));
 
         private final Pattern regex;
 

--- a/src/main/java/com/google/step/youtube/DescriptionParser.java
+++ b/src/main/java/com/google/step/youtube/DescriptionParser.java
@@ -48,7 +48,7 @@ public class DescriptionParser {
     /**
      * Finds all matches in the given string from the given regex pattern.
      *
-     * @param pattern     of the regular experssion to use for matching.
+     * @param pattern of the regular experssion to use for matching.
      * @param description of the YouTube video to be parsed.
      * @return A list of all matches found in description.
      */

--- a/src/test/java/com/google/step/youtube/DescriptionParserTest.java
+++ b/src/test/java/com/google/step/youtube/DescriptionParserTest.java
@@ -334,5 +334,20 @@ public final class DescriptionParserTest {
         assertThat(actual, equalTo(Arrays.asList("bobat15", "COOLIRPA")));
     }
 
+
+    /*                                                                   *
+     * =========== TEST 'GO TO' AND 'AT' FOR AFFILATE LINKS ============ *
+     * ex. "go to https://google.com" | "50% off at https://website.com" */
+
+    private final Pattern GOTO_AT_LINKS_PATTERN = DescriptionParser.Patterns.GOTO_AT_LINKS.getPattern();
+    
+    @Test
+    public void gotoAtLinks_lettersNumbersSymbols() {
+        String desc = "Go to https://NordVPN.com/123!pewdiepie-test and use code PEWDIEPIE to get 70% off a 3 year plan plus 1 additional month free.";
+
+        List<String> actual = DescriptionParser.findMatches(GOTO_AT_LINKS_PATTERN, desc);
+        assertThat(actual, equalTo(Arrays.asList("https://NordVPN.com/123!pewdiepie-test")));
+    }
+
 }
 

--- a/src/test/java/com/google/step/youtube/DescriptionParserTest.java
+++ b/src/test/java/com/google/step/youtube/DescriptionParserTest.java
@@ -18,61 +18,61 @@ public final class DescriptionParserTest {
     private static final Pattern CODE_WITH_QUOTES_PATTERN = DescriptionParser.Patterns.CODE_WITH_QUOTES.getPattern();
     private static final Pattern TO_AT_LINKS_PATTERN = DescriptionParser.Patterns.TO_AT_LINKS.getPattern();
 
-    /*                                                                   *
-     * ==================== GENERAL TESTS FOR PARSE ==================== *
-     *                                                                   */
+    /*
+     * * ==================== GENERAL TESTS FOR PARSE ==================== *
+     */
 
     @Test
     public void parse_matchesFromNone() {
         String desc = "Check out our UPDATED version which has all the NEW ELEMENTS here:  "
-            + "https://youtu.be/rz4Dd1I_fX0"
-            + "\nThe TEETH Song (Memorize Every Tooth): https://youtu.be/PI3hne8C8rU"
-            + "\nDownload on ITUNES: http://bit.ly/12AeW99 ";
+                + "https://youtu.be/rz4Dd1I_fX0"
+                + "\nThe TEETH Song (Memorize Every Tooth): https://youtu.be/PI3hne8C8rU"
+                + "\nDownload on ITUNES: http://bit.ly/12AeW99 ";
         assertThat(DescriptionParser.parse(desc), equalTo(Collections.emptyList()));
     }
 
     @Test
     public void parse_matchesFromAll() {
         String desc = "Get 10% off (save up to $44!) your own authentic Japanese snack box from "
-            + "Bokksu using my link: https://bit.ly/3fYbkZ5 and code FUNGBROS10. "
-            + "Save 33% on your first Native Deodorant Pack - normally $36, you'll get " 
-            + "it for $24! Click here: https://bit.ly/nativecoolirpa and use my code \"COOLIRPA\"."
-            + "Go to https://NordVPN.com/pewdiepie and use code PEWDIEPIE to "
-            + "get 70% off a 3 year plan plus 1 additional month free.";
-        assertThat(DescriptionParser.parse(desc), equalTo(Arrays.asList("FUNGBROS10", "PEWDIEPIE", 
-                                                    "COOLIRPA", "https://NordVPN.com/pewdiepie")));
+                + "Bokksu using my link: https://bit.ly/3fYbkZ5 and code FUNGBROS10. "
+                + "Save 33% on your first Native Deodorant Pack - normally $36, you'll get "
+                + "it for $24! Click here: https://bit.ly/nativecoolirpa and use my code \"COOLIRPA\"."
+                + "Go to https://NordVPN.com/pewdiepie and use code PEWDIEPIE to "
+                + "get 70% off a 3 year plan plus 1 additional month free.";
+        assertThat(DescriptionParser.parse(desc),
+                equalTo(Arrays.asList("FUNGBROS10", "PEWDIEPIE", "COOLIRPA", "https://NordVPN.com/pewdiepie")));
     }
 
     @Test
     public void parse_codeNoQuotes() {
         String desc = "Get 10% off (save up to $44!) your own authentic Japanese snack box from "
-            + "Bokksu using my link: https://bit.ly/3fYbkZ5 and code FUNGBROS10";
+                + "Bokksu using my link: https://bit.ly/3fYbkZ5 and code FUNGBROS10";
         assertThat(DescriptionParser.parse(desc), equalTo(Arrays.asList("FUNGBROS10")));
     }
 
     @Test
     public void parse_codeWithQuotes() {
-        String desc = "Save 33% on your first Native Deodorant Pack - normally $36, you'll get " 
-        + "it for $24! Click here: https://bit.ly/nativecoolirpa and use my code \"COOLIRPA\". ";
+        String desc = "Save 33% on your first Native Deodorant Pack - normally $36, you'll get "
+                + "it for $24! Click here: https://bit.ly/nativecoolirpa and use my code \"COOLIRPA\". ";
         assertThat(DescriptionParser.parse(desc), equalTo(Arrays.asList("COOLIRPA")));
     }
 
     @Test
     public void parse_toAtLink() {
         String desc = "Go to https://NordVPN.com/pewdiepie and"
-            + "get 70% off a 3 year plan plus 1 additional month free.";
+                + "get 70% off a 3 year plan plus 1 additional month free.";
         assertThat(DescriptionParser.parse(desc), equalTo(Arrays.asList("https://NordVPN.com/pewdiepie")));
     }
 
-
-    /*                                                                   *
-     * ===================== TEST 'CODE' NO QUOTES ===================== *
-     *                         ex. "code OFF20"                          */
+    /*
+     * * ===================== TEST 'CODE' NO QUOTES ===================== * ex.
+     * "code OFF20"
+     */
 
     @Test
     public void codeNoQuotes_lettersAndNumbers() {
         String desc = "Get 10% off (save up to $44!) your own authentic Japanese snack box from "
-            + "Bokksu using my link: https://bit.ly/3fYbkZ5 and code FUNGBROS10";
+                + "Bokksu using my link: https://bit.ly/3fYbkZ5 and code FUNGBROS10";
         List<String> actual = DescriptionParser.findMatches(CODE_NO_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("FUNGBROS10")));
     }
@@ -94,7 +94,7 @@ public final class DescriptionParserTest {
     @Test
     public void codeNoQuotes_1ChararcterPromocode() {
         String desc = "Get 20% off your first monthly box when you sign up at "
-            + "http://boxofawesome.com and enter the code R at checkout!";
+                + "http://boxofawesome.com and enter the code R at checkout!";
         List<String> actual = DescriptionParser.findMatches(CODE_NO_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Collections.emptyList()));
     }
@@ -102,7 +102,7 @@ public final class DescriptionParserTest {
     @Test
     public void codeNoQuotes_2CharacterPromocode() {
         String desc = "Get 20% off your first monthly box when you sign up at "
-            + "http://boxofawesome.com and enter the code RO at checkout!";
+                + "http://boxofawesome.com and enter the code RO at checkout!";
         List<String> actual = DescriptionParser.findMatches(CODE_NO_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("RO")));
     }
@@ -110,7 +110,7 @@ public final class DescriptionParserTest {
     @Test
     public void codeNoQuotes_lookbehind() {
         String desc = "Get 20% off your first monthly box when you sign up at "
-            + "http://boxofawesome.com and enter the ROOSTER code at checkout!";
+                + "http://boxofawesome.com and enter the ROOSTER code at checkout!";
         List<String> actual = DescriptionParser.findMatches(CODE_NO_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Collections.emptyList()));
     }
@@ -118,7 +118,7 @@ public final class DescriptionParserTest {
     @Test
     public void codeNoQuotes_2Spaces() {
         String desc = "Get 20% off your first monthly box when you sign up at "
-            + "http://boxofawesome.com and enter the code  ROOSTER at checkout!";
+                + "http://boxofawesome.com and enter the code  ROOSTER at checkout!";
         List<String> actual = DescriptionParser.findMatches(CODE_NO_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Collections.emptyList()));
     }
@@ -126,7 +126,7 @@ public final class DescriptionParserTest {
     @Test
     public void codeNoQuotes_newLine() {
         String desc = "Get 20% off your first monthly box when you sign up at "
-            + "http://boxofawesome.com and enter the code\nROOSTER at checkout!";
+                + "http://boxofawesome.com and enter the code\nROOSTER at checkout!";
         List<String> actual = DescriptionParser.findMatches(CODE_NO_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("ROOSTER")));
     }
@@ -134,10 +134,10 @@ public final class DescriptionParserTest {
     @Test
     public void codeNoQuotes_symbols() {
         String desc = "Get 20% off your first monthly box when you sign up at "
-            + "http://boxofawesome.com and enter the code ROOSTER! at checkout!";
+                + "http://boxofawesome.com and enter the code ROOSTER! at checkout!";
         List<String> actual = DescriptionParser.findMatches(CODE_NO_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("ROOSTER")));
-    } 
+    }
 
     @Test
     public void codeNoQuotes_keywordAtStart() {
@@ -149,7 +149,7 @@ public final class DescriptionParserTest {
     @Test
     public void codeNoQuotes_keywordAtEnd() {
         String desc = "Head to https://www.squarespace.com/boulderin... to save 10% off your "
-            + "first purchase of a website or domain using code BOULDERINGBOBAT";
+                + "first purchase of a website or domain using code BOULDERINGBOBAT";
         List<String> actual = DescriptionParser.findMatches(CODE_NO_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("BOULDERINGBOBAT")));
     }
@@ -157,7 +157,7 @@ public final class DescriptionParserTest {
     @Test
     public void codeNoQuotes_promocodeAllNumbers() {
         String desc = "Head to https://www.squarespace.com/boulderin... to save 10% off your "
-            + "first purchase of a website or domain using code 12345";
+                + "first purchase of a website or domain using code 12345";
         List<String> actual = DescriptionParser.findMatches(CODE_NO_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("12345")));
     }
@@ -165,57 +165,57 @@ public final class DescriptionParserTest {
     @Test
     public void codeNoQuotes_standaloneKeyword() {
         String desc = "Head to https://www.squarespace.com/boulderin... to save 10% off your "
-            + "first purchase of a website or domain using Decode BOULDERINGBOBAT";
+                + "first purchase of a website or domain using Decode BOULDERINGBOBAT";
         List<String> actual = DescriptionParser.findMatches(CODE_NO_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Collections.emptyList()));
-    } 
+    }
 
     @Test
     public void codeNoQuotes_multipleMatches() {
         String desc = "This episode originally recorded June 8, 2020, and is sponsored by Stamps.com "
-            + "(Go to http://stamps.com, click on the microphone at the top of the homepage, "
-            + "and type in code ROOSTERTEETH to claim your special offer), Mercari "
-            + "(Buy or sell almost anything on Mercari on the App store or at http://mercari.com), "
-            + "and Bespoke Post (Get 20% off your first monthly box when you sign up at http://boxofawesome.com "
-            + "and enter the code ROOSTER at checkout!).";
+                + "(Go to http://stamps.com, click on the microphone at the top of the homepage, "
+                + "and type in code ROOSTERTEETH to claim your special offer), Mercari "
+                + "(Buy or sell almost anything on Mercari on the App store or at http://mercari.com), "
+                + "and Bespoke Post (Get 20% off your first monthly box when you sign up at http://boxofawesome.com "
+                + "and enter the code ROOSTER at checkout!).";
         List<String> actual = DescriptionParser.findMatches(CODE_NO_QUOTES_PATTERN, desc);
         List<String> expected = Arrays.asList("ROOSTERTEETH", "ROOSTER");
         assertThat(actual, equalTo(expected));
     }
 
-
-    /*                                                                   *
-     * ==================== TEST 'CODE' WITH QUOTES ==================== *
-     *                        ex. "code "OFF20""                         */
+    /*
+     * * ==================== TEST 'CODE' WITH QUOTES ==================== * ex.
+     * "code "OFF20""
+     */
 
     @Test
     public void codeWithQuotes_lettersNumbersSymbols() {
-        String desc = "Save 33% on your first Native Deodorant Pack - normally $36, you'll get " 
-            + "it for $24! Click here: https://bit.ly/nativecoolirpa and use my code \"CooL1R-PA!\".";
+        String desc = "Save 33% on your first Native Deodorant Pack - normally $36, you'll get "
+                + "it for $24! Click here: https://bit.ly/nativecoolirpa and use my code \"CooL1R-PA!\".";
         List<String> actual = DescriptionParser.findMatches(CODE_WITH_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("CooL1R-PA!")));
     }
 
     @Test
     public void codeWithQuotes_keywordCaseInsensitive() {
-        String desc = "Save 33% on your first Native Deodorant Pack - normally $36, you'll get " 
-            + "it for $24! Click here: https://bit.ly/nativecoolirpa and use my coDe \"COOLIRPA\".";
+        String desc = "Save 33% on your first Native Deodorant Pack - normally $36, you'll get "
+                + "it for $24! Click here: https://bit.ly/nativecoolirpa and use my coDe \"COOLIRPA\".";
         List<String> actual = DescriptionParser.findMatches(CODE_WITH_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("COOLIRPA")));
     }
 
     @Test
     public void codeWithQuotes_0CharacterPromocode() {
-        String desc = "Save 33% on your first Native Deodorant Pack - normally $36, you'll get " 
-            + "it for $24! Click here: https://bit.ly/nativecoolirpa and use my coDe \"\". ";
+        String desc = "Save 33% on your first Native Deodorant Pack - normally $36, you'll get "
+                + "it for $24! Click here: https://bit.ly/nativecoolirpa and use my coDe \"\". ";
         List<String> actual = DescriptionParser.findMatches(CODE_WITH_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Collections.emptyList()));
     }
 
     @Test
     public void codeWithQuotes_1CharacterPromocode() {
-        String desc = "Save 33% on your first Native Deodorant Pack - normally $36, you'll get " 
-            + "it for $24! Click here: https://bit.ly/nativecoolirpa and use my coDe \"C\". ";
+        String desc = "Save 33% on your first Native Deodorant Pack - normally $36, you'll get "
+                + "it for $24! Click here: https://bit.ly/nativecoolirpa and use my coDe \"C\". ";
         List<String> actual = DescriptionParser.findMatches(CODE_WITH_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("C")));
     }
@@ -223,7 +223,7 @@ public final class DescriptionParserTest {
     @Test
     public void codeWithQuotes_keywordAtStart() {
         String desc = "Code \"COOLIRPA\" and save 33% on your first Native Deodorant Pack - "
-            + "normally $36, you'll get it for $24! Click here: https://bit.ly/nativecoolirpa.";
+                + "normally $36, you'll get it for $24! Click here: https://bit.ly/nativecoolirpa.";
         List<String> actual = DescriptionParser.findMatches(CODE_WITH_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("COOLIRPA")));
     }
@@ -231,7 +231,7 @@ public final class DescriptionParserTest {
     @Test
     public void codeWithQuotes_keywordAtEnd() {
         String desc = "Get %15 off Rhino Skin, Unparallel shoes and much more at "
-            + "https://darkventures.co.uk/shop with offer code \"bobat15\"";
+                + "https://darkventures.co.uk/shop with offer code \"bobat15\"";
         List<String> actual = DescriptionParser.findMatches(CODE_WITH_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("bobat15")));
     }
@@ -239,7 +239,7 @@ public final class DescriptionParserTest {
     @Test
     public void codeWithQuotes_2Spaces() {
         String desc = "Get %15 off Rhino Skin, Unparallel shoes and much more at "
-            + "https://darkventures.co.uk/shop with offer code  \"bobat15\"";
+                + "https://darkventures.co.uk/shop with offer code  \"bobat15\"";
         List<String> actual = DescriptionParser.findMatches(CODE_WITH_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Collections.emptyList()));
     }
@@ -247,7 +247,7 @@ public final class DescriptionParserTest {
     @Test
     public void codeWithQuotes_newLineBetween() {
         String desc = "Get %15 off Rhino Skin, Unparallel shoes and much more at "
-            + "https://darkventures.co.uk/shop with offer code\n\"bobat15\"";
+                + "https://darkventures.co.uk/shop with offer code\n\"bobat15\"";
         List<String> actual = DescriptionParser.findMatches(CODE_WITH_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("bobat15")));
     }
@@ -255,7 +255,7 @@ public final class DescriptionParserTest {
     @Test
     public void codeWithQuotes_newLineInsideQuotes() {
         String desc = "Get %15 off Rhino Skin, Unparallel shoes and much more at "
-            + "https://darkventures.co.uk/shop with offer code \"boba\nt15\"";
+                + "https://darkventures.co.uk/shop with offer code \"boba\nt15\"";
         List<String> actual = DescriptionParser.findMatches(CODE_WITH_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Collections.emptyList()));
     }
@@ -263,7 +263,7 @@ public final class DescriptionParserTest {
     @Test
     public void codeWithQuotes_lookbehind() {
         String desc = "Get %15 off Rhino Skin, Unparallel shoes and much more at "
-            + "https://darkventures.co.uk/shop with offer \"bobat15\" code";
+                + "https://darkventures.co.uk/shop with offer \"bobat15\" code";
         List<String> actual = DescriptionParser.findMatches(CODE_WITH_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Collections.emptyList()));
     }
@@ -271,16 +271,16 @@ public final class DescriptionParserTest {
     @Test
     public void codeWithQuotes_standaloneKeyword() {
         String desc = "Get %15 off Rhino Skin, Unparallel shoes and much more at "
-            + "https://darkventures.co.uk/shop with offer decode \"bobat15\"";
+                + "https://darkventures.co.uk/shop with offer decode \"bobat15\"";
         List<String> actual = DescriptionParser.findMatches(CODE_WITH_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Collections.emptyList()));
     }
 
-    // lazy matching: end match at first set of quotes encountered 
+    // lazy matching: end match at first set of quotes encountered
     @Test
     public void codeWithQuotes_lazyMatching() {
         String desc = "Get %15 off Rhino Skin, Unparallel shoes and much more at "
-            + "https://darkventures.co.uk/shop with offer code \"bobat\"15\"";
+                + "https://darkventures.co.uk/shop with offer code \"bobat\"15\"";
         List<String> actual = DescriptionParser.findMatches(CODE_WITH_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("bobat")));
     }
@@ -288,7 +288,7 @@ public final class DescriptionParserTest {
     @Test
     public void codeWithQuotes_singleQuotes() {
         String desc = "Get %15 off Rhino Skin, Unparallel shoes and much more at "
-            + "https://darkventures.co.uk/shop with offer code 'bobat15'";
+                + "https://darkventures.co.uk/shop with offer code 'bobat15'";
         List<String> actual = DescriptionParser.findMatches(CODE_WITH_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("bobat15")));
     }
@@ -296,7 +296,7 @@ public final class DescriptionParserTest {
     @Test
     public void codeWithQuotes_singleAndDoubleQuotes() {
         String desc = "Get %15 off Rhino Skin, Unparallel shoes and much more at "
-            + "https://darkventures.co.uk/shop with offer code \"bobat15'";
+                + "https://darkventures.co.uk/shop with offer code \"bobat15'";
         List<String> actual = DescriptionParser.findMatches(CODE_WITH_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("bobat15")));
     }
@@ -304,22 +304,22 @@ public final class DescriptionParserTest {
     @Test
     public void codeWithQuotes_multipleMatches() {
         String desc = "Get %15 off Rhino Skin, Unparallel shoes and much more at "
-            + "https://darkventures.co.uk/shop with offer code 'bobat15'"
-            + "Save 33% on your first Native Deodorant Pack - normally $36, you'll get it for "
-            + "$24! Click here: https://bit.ly/nativecoolirpa and use my code \"COOLIRPA\".";
+                + "https://darkventures.co.uk/shop with offer code 'bobat15'"
+                + "Save 33% on your first Native Deodorant Pack - normally $36, you'll get it for "
+                + "$24! Click here: https://bit.ly/nativecoolirpa and use my code \"COOLIRPA\".";
         List<String> actual = DescriptionParser.findMatches(CODE_WITH_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("bobat15", "COOLIRPA")));
     }
 
+    /*
+     * * ============= TEST 'TO' AND 'AT' FOR AFFILATE LINKS ============= * ex.
+     * "go to https://google.com" | "50% off at https://website.com"
+     */
 
-    /*                                                                   *
-     * ============= TEST 'TO' AND 'AT' FOR AFFILATE LINKS ============= *
-     * ex. "go to https://google.com" | "50% off at https://website.com" */
-    
     @Test
     public void toAtLinks_lettersNumbersSymbols() {
         String desc = "Go to https://NordVPN.com/123!pewdiepie-test and use code PEWDIEPIE to "
-            + "get 70% off a 3 year plan plus 1 additional month free.";
+                + "get 70% off a 3 year plan plus 1 additional month free.";
         List<String> actual = DescriptionParser.findMatches(TO_AT_LINKS_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("https://NordVPN.com/123!pewdiepie-test")));
     }
@@ -327,7 +327,7 @@ public final class DescriptionParserTest {
     @Test
     public void toAtLinks_toCaseInsensitive() {
         String desc = "Go tO https://NordVPN.com/pewdiepie and use code PEWDIEPIE to "
-            + "get 70% off a 3 year plan plus 1 additional month free.";
+                + "get 70% off a 3 year plan plus 1 additional month free.";
         List<String> actual = DescriptionParser.findMatches(TO_AT_LINKS_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("https://NordVPN.com/pewdiepie")));
     }
@@ -342,7 +342,7 @@ public final class DescriptionParserTest {
     @Test
     public void toAtLinks_0CharacterLinkBody() {
         String desc = "Get 20% off your first monthly box when you sign up at "
-            + "http:// and enter the code ROOSTER at checkout!";
+                + "http:// and enter the code ROOSTER at checkout!";
         List<String> actual = DescriptionParser.findMatches(TO_AT_LINKS_PATTERN, desc);
         assertThat(actual, equalTo(Collections.emptyList()));
     }
@@ -350,7 +350,7 @@ public final class DescriptionParserTest {
     @Test
     public void toAtLinks_1CharacterLinkBody() {
         String desc = "Get 20% off your first monthly box when you sign up at "
-            + "http://a and enter the code ROOSTER at checkout!";
+                + "http://a and enter the code ROOSTER at checkout!";
         List<String> actual = DescriptionParser.findMatches(TO_AT_LINKS_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("http://a")));
     }
@@ -358,8 +358,8 @@ public final class DescriptionParserTest {
     @Test
     public void toAtLinks_multipleMatchesHttpsAndHttp() {
         String desc = "Go to https://NordVPN.com/pewdiepie and use code PEWDIEPIE to get 70% "
-            + "off a 3 year plan plus 1 additional month free."
-            + "Go to http://stamps.com, click on the microphone at the top of the homepage";
+                + "off a 3 year plan plus 1 additional month free."
+                + "Go to http://stamps.com, click on the microphone at the top of the homepage";
         List<String> actual = DescriptionParser.findMatches(TO_AT_LINKS_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("https://NordVPN.com/pewdiepie", "http://stamps.com")));
     }
@@ -367,11 +367,11 @@ public final class DescriptionParserTest {
     @Test
     public void toAtLinks_noHttpOnlyWWW() {
         String desc = "Go to www.NordVPN.com/pewdiepie and use code PEWDIEPIE to get 70% "
-            + "off a 3 year plan plus 1 additional month free.";
+                + "off a 3 year plan plus 1 additional month free.";
         List<String> actual = DescriptionParser.findMatches(TO_AT_LINKS_PATTERN, desc);
         assertThat(actual, equalTo(Collections.emptyList()));
     }
-    
+
     @Test
     public void toAtLinks_lookbehind() {
         String desc = "Use code LINUS and get 25% off GlassWire https://lmg.gg/glasswire at";
@@ -424,7 +424,7 @@ public final class DescriptionParserTest {
     @Test
     public void toAtLinks_stopMatchingAtSpace() {
         String desc = "Head to https://www.squarespace.com/boulderin... to save 10% off your "
-            + "first purchase of a website or domain using code BOULDERINGBOBAT. ";
+                + "first purchase of a website or domain using code BOULDERINGBOBAT. ";
         List<String> actual = DescriptionParser.findMatches(TO_AT_LINKS_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("https://www.squarespace.com/boulderin...")));
     }
@@ -432,7 +432,7 @@ public final class DescriptionParserTest {
     @Test
     public void toAtLinks_stopMatchingAtNewline() {
         String desc = "Head to https://www.squarespace.com/boulderin...\nto save 10% off your "
-            + "first purchase of a website or domain using code BOULDERINGBOBAT. ";
+                + "first purchase of a website or domain using code BOULDERINGBOBAT. ";
         List<String> actual = DescriptionParser.findMatches(TO_AT_LINKS_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("https://www.squarespace.com/boulderin...")));
     }
@@ -452,4 +452,3 @@ public final class DescriptionParserTest {
     }
 
 }
-

--- a/src/test/java/com/google/step/youtube/DescriptionParserTest.java
+++ b/src/test/java/com/google/step/youtube/DescriptionParserTest.java
@@ -176,8 +176,8 @@ public final class DescriptionParserTest {
                 + "(Go to http://stamps.com, click on the microphone at the top of the homepage, "
                 + "and type in code ROOSTERTEETH to claim your special offer), Mercari "
                 + "(Buy or sell almost anything on Mercari on the App store or at http://mercari.com), "
-                + "and Bespoke Post (Get 20% off your first monthly box when you sign up at http://boxofawesome.com "
-                + "and enter the code ROOSTER at checkout!).";
+                + "and Bespoke Post (Get 20% off your first monthly box when you sign up at "
+                + "http://boxofawesome.com and enter the code ROOSTER at checkout!).";
         List<String> actual = DescriptionParser.findMatches(CODE_NO_QUOTES_PATTERN, desc);
         List<String> expected = Arrays.asList("ROOSTERTEETH", "ROOSTER");
         assertThat(actual, equalTo(expected));

--- a/src/test/java/com/google/step/youtube/DescriptionParserTest.java
+++ b/src/test/java/com/google/step/youtube/DescriptionParserTest.java
@@ -14,6 +14,10 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public final class DescriptionParserTest {
 
+    private static final Pattern CODE_NO_QUOTES_PATTERN = DescriptionParser.Patterns.CODE_NO_QUOTES.getPattern();
+    private static final Pattern CODE_WITH_QUOTES_PATTERN = DescriptionParser.Patterns.CODE_WITH_QUOTES.getPattern();
+    private static final Pattern TO_AT_LINKS_PATTERN = DescriptionParser.Patterns.TO_AT_LINKS.getPattern();
+
     /*                                                                   *
      * ==================== GENERAL TESTS FOR PARSE ==================== *
      *                                                                   */
@@ -24,7 +28,6 @@ public final class DescriptionParserTest {
             + "https://youtu.be/rz4Dd1I_fX0"
             + "\nThe TEETH Song (Memorize Every Tooth): https://youtu.be/PI3hne8C8rU"
             + "\nDownload on ITUNES: http://bit.ly/12AeW99 ";
-
         assertThat(DescriptionParser.parse(desc), equalTo(Collections.emptyList()));
     }
 
@@ -36,7 +39,6 @@ public final class DescriptionParserTest {
             + "it for $24! Click here: https://bit.ly/nativecoolirpa and use my code \"COOLIRPA\"."
             + "Go to https://NordVPN.com/pewdiepie and use code PEWDIEPIE to "
             + "get 70% off a 3 year plan plus 1 additional month free.";
-
         assertThat(DescriptionParser.parse(desc), equalTo(Arrays.asList("FUNGBROS10", "PEWDIEPIE", 
                                                     "COOLIRPA", "https://NordVPN.com/pewdiepie")));
     }
@@ -45,7 +47,6 @@ public final class DescriptionParserTest {
     public void parse_codeNoQuotes() {
         String desc = "Get 10% off (save up to $44!) your own authentic Japanese snack box from "
             + "Bokksu using my link: https://bit.ly/3fYbkZ5 and code FUNGBROS10";
-
         assertThat(DescriptionParser.parse(desc), equalTo(Arrays.asList("FUNGBROS10")));
     }
 
@@ -53,7 +54,6 @@ public final class DescriptionParserTest {
     public void parse_codeWithQuotes() {
         String desc = "Save 33% on your first Native Deodorant Pack - normally $36, you'll get " 
         + "it for $24! Click here: https://bit.ly/nativecoolirpa and use my code \"COOLIRPA\". ";
-
         assertThat(DescriptionParser.parse(desc), equalTo(Arrays.asList("COOLIRPA")));
     }
 
@@ -61,7 +61,6 @@ public final class DescriptionParserTest {
     public void parse_toAtLink() {
         String desc = "Go to https://NordVPN.com/pewdiepie and"
             + "get 70% off a 3 year plan plus 1 additional month free.";
-
         assertThat(DescriptionParser.parse(desc), equalTo(Arrays.asList("https://NordVPN.com/pewdiepie")));
     }
 
@@ -70,13 +69,10 @@ public final class DescriptionParserTest {
      * ===================== TEST 'CODE' NO QUOTES ===================== *
      *                         ex. "code OFF20"                          */
 
-    private static final Pattern CODE_NO_QUOTES_PATTERN = DescriptionParser.Patterns.CODE_NO_QUOTES.getPattern();
-
     @Test
     public void codeNoQuotes_lettersAndNumbers() {
         String desc = "Get 10% off (save up to $44!) your own authentic Japanese snack box from "
             + "Bokksu using my link: https://bit.ly/3fYbkZ5 and code FUNGBROS10";
-
         List<String> actual = DescriptionParser.findMatches(CODE_NO_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("FUNGBROS10")));
     }
@@ -84,7 +80,6 @@ public final class DescriptionParserTest {
     @Test
     public void codeNoQuotes_promocodeCaseSensitive() {
         String desc = "Use code LINUSsssS and get 25% off GlassWire at https://lmg.gg/glasswire";
-
         List<String> actual = DescriptionParser.findMatches(CODE_NO_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("LINUS")));
     }
@@ -92,7 +87,6 @@ public final class DescriptionParserTest {
     @Test
     public void codeNoQuotes_keywordCaseInsensitive() {
         String desc = "Use cOdE LINUS and get 25% off GlassWire at https://lmg.gg/glasswire";
-
         List<String> actual = DescriptionParser.findMatches(CODE_NO_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("LINUS")));
     }
@@ -101,7 +95,6 @@ public final class DescriptionParserTest {
     public void codeNoQuotes_1ChararcterPromocode() {
         String desc = "Get 20% off your first monthly box when you sign up at "
             + "http://boxofawesome.com and enter the code R at checkout!";
-
         List<String> actual = DescriptionParser.findMatches(CODE_NO_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Collections.emptyList()));
     }
@@ -110,7 +103,6 @@ public final class DescriptionParserTest {
     public void codeNoQuotes_2CharacterPromocode() {
         String desc = "Get 20% off your first monthly box when you sign up at "
             + "http://boxofawesome.com and enter the code RO at checkout!";
-
         List<String> actual = DescriptionParser.findMatches(CODE_NO_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("RO")));
     }
@@ -119,7 +111,6 @@ public final class DescriptionParserTest {
     public void codeNoQuotes_lookbehind() {
         String desc = "Get 20% off your first monthly box when you sign up at "
             + "http://boxofawesome.com and enter the ROOSTER code at checkout!";
-
         List<String> actual = DescriptionParser.findMatches(CODE_NO_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Collections.emptyList()));
     }
@@ -128,7 +119,6 @@ public final class DescriptionParserTest {
     public void codeNoQuotes_2Spaces() {
         String desc = "Get 20% off your first monthly box when you sign up at "
             + "http://boxofawesome.com and enter the code  ROOSTER at checkout!";
-
         List<String> actual = DescriptionParser.findMatches(CODE_NO_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Collections.emptyList()));
     }
@@ -137,7 +127,6 @@ public final class DescriptionParserTest {
     public void codeNoQuotes_newLine() {
         String desc = "Get 20% off your first monthly box when you sign up at "
             + "http://boxofawesome.com and enter the code\nROOSTER at checkout!";
-
         List<String> actual = DescriptionParser.findMatches(CODE_NO_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("ROOSTER")));
     }
@@ -146,7 +135,6 @@ public final class DescriptionParserTest {
     public void codeNoQuotes_symbols() {
         String desc = "Get 20% off your first monthly box when you sign up at "
             + "http://boxofawesome.com and enter the code ROOSTER! at checkout!";
-
         List<String> actual = DescriptionParser.findMatches(CODE_NO_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("ROOSTER")));
     } 
@@ -154,7 +142,6 @@ public final class DescriptionParserTest {
     @Test
     public void codeNoQuotes_keywordAtStart() {
         String desc = "code LINUS and get 25% off GlassWire at https://lmg.gg/glasswire";
-
         List<String> actual = DescriptionParser.findMatches(CODE_NO_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("LINUS")));
     }
@@ -163,7 +150,6 @@ public final class DescriptionParserTest {
     public void codeNoQuotes_keywordAtEnd() {
         String desc = "Head to https://www.squarespace.com/boulderin... to save 10% off your "
             + "first purchase of a website or domain using code BOULDERINGBOBAT";
-
         List<String> actual = DescriptionParser.findMatches(CODE_NO_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("BOULDERINGBOBAT")));
     }
@@ -172,7 +158,6 @@ public final class DescriptionParserTest {
     public void codeNoQuotes_promocodeAllNumbers() {
         String desc = "Head to https://www.squarespace.com/boulderin... to save 10% off your "
             + "first purchase of a website or domain using code 12345";
-
         List<String> actual = DescriptionParser.findMatches(CODE_NO_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("12345")));
     }
@@ -181,7 +166,6 @@ public final class DescriptionParserTest {
     public void codeNoQuotes_standaloneKeyword() {
         String desc = "Head to https://www.squarespace.com/boulderin... to save 10% off your "
             + "first purchase of a website or domain using Decode BOULDERINGBOBAT";
-
         List<String> actual = DescriptionParser.findMatches(CODE_NO_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Collections.emptyList()));
     } 
@@ -194,7 +178,6 @@ public final class DescriptionParserTest {
             + "(Buy or sell almost anything on Mercari on the App store or at http://mercari.com), "
             + "and Bespoke Post (Get 20% off your first monthly box when you sign up at http://boxofawesome.com "
             + "and enter the code ROOSTER at checkout!).";
-
         List<String> actual = DescriptionParser.findMatches(CODE_NO_QUOTES_PATTERN, desc);
         List<String> expected = Arrays.asList("ROOSTERTEETH", "ROOSTER");
         assertThat(actual, equalTo(expected));
@@ -205,13 +188,10 @@ public final class DescriptionParserTest {
      * ==================== TEST 'CODE' WITH QUOTES ==================== *
      *                        ex. "code "OFF20""                         */
 
-    private static final Pattern CODE_WITH_QUOTES_PATTERN = DescriptionParser.Patterns.CODE_WITH_QUOTES.getPattern();
-
     @Test
     public void codeWithQuotes_lettersNumbersSymbols() {
         String desc = "Save 33% on your first Native Deodorant Pack - normally $36, you'll get " 
             + "it for $24! Click here: https://bit.ly/nativecoolirpa and use my code \"CooL1R-PA!\".";
-
         List<String> actual = DescriptionParser.findMatches(CODE_WITH_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("CooL1R-PA!")));
     }
@@ -220,7 +200,6 @@ public final class DescriptionParserTest {
     public void codeWithQuotes_keywordCaseInsensitive() {
         String desc = "Save 33% on your first Native Deodorant Pack - normally $36, you'll get " 
             + "it for $24! Click here: https://bit.ly/nativecoolirpa and use my coDe \"COOLIRPA\".";
-
         List<String> actual = DescriptionParser.findMatches(CODE_WITH_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("COOLIRPA")));
     }
@@ -229,7 +208,6 @@ public final class DescriptionParserTest {
     public void codeWithQuotes_0CharacterPromocode() {
         String desc = "Save 33% on your first Native Deodorant Pack - normally $36, you'll get " 
             + "it for $24! Click here: https://bit.ly/nativecoolirpa and use my coDe \"\". ";
-
         List<String> actual = DescriptionParser.findMatches(CODE_WITH_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Collections.emptyList()));
     }
@@ -238,7 +216,6 @@ public final class DescriptionParserTest {
     public void codeWithQuotes_1CharacterPromocode() {
         String desc = "Save 33% on your first Native Deodorant Pack - normally $36, you'll get " 
             + "it for $24! Click here: https://bit.ly/nativecoolirpa and use my coDe \"C\". ";
-
         List<String> actual = DescriptionParser.findMatches(CODE_WITH_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("C")));
     }
@@ -247,7 +224,6 @@ public final class DescriptionParserTest {
     public void codeWithQuotes_keywordAtStart() {
         String desc = "Code \"COOLIRPA\" and save 33% on your first Native Deodorant Pack - "
             + "normally $36, you'll get it for $24! Click here: https://bit.ly/nativecoolirpa.";
-
         List<String> actual = DescriptionParser.findMatches(CODE_WITH_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("COOLIRPA")));
     }
@@ -256,7 +232,6 @@ public final class DescriptionParserTest {
     public void codeWithQuotes_keywordAtEnd() {
         String desc = "Get %15 off Rhino Skin, Unparallel shoes and much more at "
             + "https://darkventures.co.uk/shop with offer code \"bobat15\"";
-
         List<String> actual = DescriptionParser.findMatches(CODE_WITH_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("bobat15")));
     }
@@ -265,7 +240,6 @@ public final class DescriptionParserTest {
     public void codeWithQuotes_2Spaces() {
         String desc = "Get %15 off Rhino Skin, Unparallel shoes and much more at "
             + "https://darkventures.co.uk/shop with offer code  \"bobat15\"";
-
         List<String> actual = DescriptionParser.findMatches(CODE_WITH_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Collections.emptyList()));
     }
@@ -274,7 +248,6 @@ public final class DescriptionParserTest {
     public void codeWithQuotes_newLineBetween() {
         String desc = "Get %15 off Rhino Skin, Unparallel shoes and much more at "
             + "https://darkventures.co.uk/shop with offer code\n\"bobat15\"";
-
         List<String> actual = DescriptionParser.findMatches(CODE_WITH_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("bobat15")));
     }
@@ -283,7 +256,6 @@ public final class DescriptionParserTest {
     public void codeWithQuotes_newLineInsideQuotes() {
         String desc = "Get %15 off Rhino Skin, Unparallel shoes and much more at "
             + "https://darkventures.co.uk/shop with offer code \"boba\nt15\"";
-
         List<String> actual = DescriptionParser.findMatches(CODE_WITH_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Collections.emptyList()));
     }
@@ -292,7 +264,6 @@ public final class DescriptionParserTest {
     public void codeWithQuotes_lookbehind() {
         String desc = "Get %15 off Rhino Skin, Unparallel shoes and much more at "
             + "https://darkventures.co.uk/shop with offer \"bobat15\" code";
-
         List<String> actual = DescriptionParser.findMatches(CODE_WITH_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Collections.emptyList()));
     }
@@ -301,7 +272,6 @@ public final class DescriptionParserTest {
     public void codeWithQuotes_standaloneKeyword() {
         String desc = "Get %15 off Rhino Skin, Unparallel shoes and much more at "
             + "https://darkventures.co.uk/shop with offer decode \"bobat15\"";
-
         List<String> actual = DescriptionParser.findMatches(CODE_WITH_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Collections.emptyList()));
     }
@@ -311,7 +281,6 @@ public final class DescriptionParserTest {
     public void codeWithQuotes_lazyMatching() {
         String desc = "Get %15 off Rhino Skin, Unparallel shoes and much more at "
             + "https://darkventures.co.uk/shop with offer code \"bobat\"15\"";
-
         List<String> actual = DescriptionParser.findMatches(CODE_WITH_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("bobat")));
     }
@@ -320,7 +289,6 @@ public final class DescriptionParserTest {
     public void codeWithQuotes_singleQuotes() {
         String desc = "Get %15 off Rhino Skin, Unparallel shoes and much more at "
             + "https://darkventures.co.uk/shop with offer code 'bobat15'";
-
         List<String> actual = DescriptionParser.findMatches(CODE_WITH_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("bobat15")));
     }
@@ -329,7 +297,6 @@ public final class DescriptionParserTest {
     public void codeWithQuotes_singleAndDoubleQuotes() {
         String desc = "Get %15 off Rhino Skin, Unparallel shoes and much more at "
             + "https://darkventures.co.uk/shop with offer code \"bobat15'";
-
         List<String> actual = DescriptionParser.findMatches(CODE_WITH_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("bobat15")));
     }
@@ -340,7 +307,6 @@ public final class DescriptionParserTest {
             + "https://darkventures.co.uk/shop with offer code 'bobat15'"
             + "Save 33% on your first Native Deodorant Pack - normally $36, you'll get it for "
             + "$24! Click here: https://bit.ly/nativecoolirpa and use my code \"COOLIRPA\".";
-
         List<String> actual = DescriptionParser.findMatches(CODE_WITH_QUOTES_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("bobat15", "COOLIRPA")));
     }
@@ -349,14 +315,11 @@ public final class DescriptionParserTest {
     /*                                                                   *
      * ============= TEST 'TO' AND 'AT' FOR AFFILATE LINKS ============= *
      * ex. "go to https://google.com" | "50% off at https://website.com" */
-
-    private final Pattern TO_AT_LINKS_PATTERN = DescriptionParser.Patterns.TO_AT_LINKS.getPattern();
     
     @Test
     public void toAtLinks_lettersNumbersSymbols() {
         String desc = "Go to https://NordVPN.com/123!pewdiepie-test and use code PEWDIEPIE to "
             + "get 70% off a 3 year plan plus 1 additional month free.";
-
         List<String> actual = DescriptionParser.findMatches(TO_AT_LINKS_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("https://NordVPN.com/123!pewdiepie-test")));
     }
@@ -365,7 +328,6 @@ public final class DescriptionParserTest {
     public void toAtLinks_toCaseInsensitive() {
         String desc = "Go tO https://NordVPN.com/pewdiepie and use code PEWDIEPIE to "
             + "get 70% off a 3 year plan plus 1 additional month free.";
-
         List<String> actual = DescriptionParser.findMatches(TO_AT_LINKS_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("https://NordVPN.com/pewdiepie")));
     }
@@ -373,7 +335,6 @@ public final class DescriptionParserTest {
     @Test
     public void toAtLinks_atCaseInsensitive() {
         String desc = "Get 20% off your first monthly box when you sign up AT http://boxofawesome.com";
-
         List<String> actual = DescriptionParser.findMatches(TO_AT_LINKS_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("http://boxofawesome.com")));
     }
@@ -382,7 +343,6 @@ public final class DescriptionParserTest {
     public void toAtLinks_0CharacterLinkBody() {
         String desc = "Get 20% off your first monthly box when you sign up at "
             + "http:// and enter the code ROOSTER at checkout!";
-
         List<String> actual = DescriptionParser.findMatches(TO_AT_LINKS_PATTERN, desc);
         assertThat(actual, equalTo(Collections.emptyList()));
     }
@@ -391,7 +351,6 @@ public final class DescriptionParserTest {
     public void toAtLinks_1CharacterLinkBody() {
         String desc = "Get 20% off your first monthly box when you sign up at "
             + "http://a and enter the code ROOSTER at checkout!";
-
         List<String> actual = DescriptionParser.findMatches(TO_AT_LINKS_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("http://a")));
     }
@@ -401,7 +360,6 @@ public final class DescriptionParserTest {
         String desc = "Go to https://NordVPN.com/pewdiepie and use code PEWDIEPIE to get 70% "
             + "off a 3 year plan plus 1 additional month free."
             + "Go to http://stamps.com, click on the microphone at the top of the homepage";
-
         List<String> actual = DescriptionParser.findMatches(TO_AT_LINKS_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("https://NordVPN.com/pewdiepie", "http://stamps.com")));
     }
@@ -410,7 +368,6 @@ public final class DescriptionParserTest {
     public void toAtLinks_noHttpOnlyWWW() {
         String desc = "Go to www.NordVPN.com/pewdiepie and use code PEWDIEPIE to get 70% "
             + "off a 3 year plan plus 1 additional month free.";
-
         List<String> actual = DescriptionParser.findMatches(TO_AT_LINKS_PATTERN, desc);
         assertThat(actual, equalTo(Collections.emptyList()));
     }
@@ -418,7 +375,6 @@ public final class DescriptionParserTest {
     @Test
     public void toAtLinks_lookbehind() {
         String desc = "Use code LINUS and get 25% off GlassWire https://lmg.gg/glasswire at";
-
         List<String> actual = DescriptionParser.findMatches(TO_AT_LINKS_PATTERN, desc);
         assertThat(actual, equalTo(Collections.emptyList()));
     }
@@ -426,7 +382,6 @@ public final class DescriptionParserTest {
     @Test
     public void toAtLinks_standaloneAt() {
         String desc = "Use code LINUS and get 25% off GlassWire what https://lmg.gg/glasswire";
-
         List<String> actual = DescriptionParser.findMatches(TO_AT_LINKS_PATTERN, desc);
         assertThat(actual, equalTo(Collections.emptyList()));
     }
@@ -434,7 +389,6 @@ public final class DescriptionParserTest {
     @Test
     public void toAtLinks_standaloneTo() {
         String desc = "Use code LINUS and get 25% off GlassWire burrito https://lmg.gg/glasswire";
-
         List<String> actual = DescriptionParser.findMatches(TO_AT_LINKS_PATTERN, desc);
         assertThat(actual, equalTo(Collections.emptyList()));
     }
@@ -442,7 +396,6 @@ public final class DescriptionParserTest {
     @Test
     public void toAtLinks_keywordAtStart() {
         String desc = "At https://lmg.gg/glasswire use code LINUS and get 25% off GlassWire";
-
         List<String> actual = DescriptionParser.findMatches(TO_AT_LINKS_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("https://lmg.gg/glasswire")));
     }
@@ -450,7 +403,6 @@ public final class DescriptionParserTest {
     @Test
     public void toAtLinks_keywordAtEnd() {
         String desc = "Use code LINUS and get 25% off GlassWire at https://lmg.gg/glasswire";
-
         List<String> actual = DescriptionParser.findMatches(TO_AT_LINKS_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("https://lmg.gg/glasswire")));
     }
@@ -458,7 +410,6 @@ public final class DescriptionParserTest {
     @Test
     public void toAtLinks_2SpacesBetween() {
         String desc = "Use code LINUS and get 25% off GlassWire at  https://lmg.gg/glasswire";
-
         List<String> actual = DescriptionParser.findMatches(TO_AT_LINKS_PATTERN, desc);
         assertThat(actual, equalTo(Collections.emptyList()));
     }
@@ -466,7 +417,6 @@ public final class DescriptionParserTest {
     @Test
     public void toAtLinks_newLineBetween() {
         String desc = "Use code LINUS and get 25% off GlassWire at\nhttps://lmg.gg/glasswire";
-
         List<String> actual = DescriptionParser.findMatches(TO_AT_LINKS_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("https://lmg.gg/glasswire")));
     }
@@ -475,7 +425,6 @@ public final class DescriptionParserTest {
     public void toAtLinks_stopMatchingAtSpace() {
         String desc = "Head to https://www.squarespace.com/boulderin... to save 10% off your "
             + "first purchase of a website or domain using code BOULDERINGBOBAT. ";
-
         List<String> actual = DescriptionParser.findMatches(TO_AT_LINKS_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("https://www.squarespace.com/boulderin...")));
     }
@@ -484,7 +433,6 @@ public final class DescriptionParserTest {
     public void toAtLinks_stopMatchingAtNewline() {
         String desc = "Head to https://www.squarespace.com/boulderin...\nto save 10% off your "
             + "first purchase of a website or domain using code BOULDERINGBOBAT. ";
-
         List<String> actual = DescriptionParser.findMatches(TO_AT_LINKS_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("https://www.squarespace.com/boulderin...")));
     }
@@ -492,7 +440,6 @@ public final class DescriptionParserTest {
     @Test
     public void toAtLinks_stopMatchingAtComma() {
         String desc = "Go to http://stamps.com, click on the microphone";
-
         List<String> actual = DescriptionParser.findMatches(TO_AT_LINKS_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("http://stamps.com")));
     }
@@ -500,7 +447,6 @@ public final class DescriptionParserTest {
     @Test
     public void toAtLinks_stopMatchingAtCloseParens() {
         String desc = "Buy or sell almost anything on Mercari on the App store or at http://mercari.com)";
-
         List<String> actual = DescriptionParser.findMatches(TO_AT_LINKS_PATTERN, desc);
         assertThat(actual, equalTo(Arrays.asList("http://mercari.com")));
     }

--- a/src/test/java/com/google/step/youtube/DescriptionParserTest.java
+++ b/src/test/java/com/google/step/youtube/DescriptionParserTest.java
@@ -439,5 +439,71 @@ public final class DescriptionParserTest {
         assertThat(actual, equalTo(Collections.emptyList()));
     }
 
+    @Test
+    public void toAtLinks_keywordAtStart() {
+        String desc = "At https://lmg.gg/glasswire use code LINUS and get 25% off GlassWire";
+
+        List<String> actual = DescriptionParser.findMatches(TO_AT_LINKS_PATTERN, desc);
+        assertThat(actual, equalTo(Arrays.asList("https://lmg.gg/glasswire")));
+    }
+
+    @Test
+    public void toAtLinks_keywordAtEnd() {
+        String desc = "Use code LINUS and get 25% off GlassWire at https://lmg.gg/glasswire";
+
+        List<String> actual = DescriptionParser.findMatches(TO_AT_LINKS_PATTERN, desc);
+        assertThat(actual, equalTo(Arrays.asList("https://lmg.gg/glasswire")));
+    }
+
+    @Test
+    public void toAtLinks_2SpacesBetween() {
+        String desc = "Use code LINUS and get 25% off GlassWire at  https://lmg.gg/glasswire";
+
+        List<String> actual = DescriptionParser.findMatches(TO_AT_LINKS_PATTERN, desc);
+        assertThat(actual, equalTo(Collections.emptyList()));
+    }
+
+    @Test
+    public void toAtLinks_newLineBetween() {
+        String desc = "Use code LINUS and get 25% off GlassWire at\nhttps://lmg.gg/glasswire";
+
+        List<String> actual = DescriptionParser.findMatches(TO_AT_LINKS_PATTERN, desc);
+        assertThat(actual, equalTo(Arrays.asList("https://lmg.gg/glasswire")));
+    }
+
+    @Test
+    public void toAtLinks_stopMatchingAtSpace() {
+        String desc = "Head to https://www.squarespace.com/boulderin... to save 10% off your "
+            + "first purchase of a website or domain using code BOULDERINGBOBAT. ";
+
+        List<String> actual = DescriptionParser.findMatches(TO_AT_LINKS_PATTERN, desc);
+        assertThat(actual, equalTo(Arrays.asList("https://www.squarespace.com/boulderin...")));
+    }
+
+    @Test
+    public void toAtLinks_stopMatchingAtNewline() {
+        String desc = "Head to https://www.squarespace.com/boulderin...\nto save 10% off your "
+            + "first purchase of a website or domain using code BOULDERINGBOBAT. ";
+
+        List<String> actual = DescriptionParser.findMatches(TO_AT_LINKS_PATTERN, desc);
+        assertThat(actual, equalTo(Arrays.asList("https://www.squarespace.com/boulderin...")));
+    }
+
+    @Test
+    public void toAtLinks_stopMatchingAtComma() {
+        String desc = "Go to http://stamps.com, click on the microphone";
+
+        List<String> actual = DescriptionParser.findMatches(TO_AT_LINKS_PATTERN, desc);
+        assertThat(actual, equalTo(Arrays.asList("http://stamps.com")));
+    }
+
+    @Test
+    public void toAtLinks_stopMatchingAtCloseParens() {
+        String desc = "Buy or sell almost anything on Mercari on the App store or at http://mercari.com)";
+
+        List<String> actual = DescriptionParser.findMatches(TO_AT_LINKS_PATTERN, desc);
+        assertThat(actual, equalTo(Arrays.asList("http://mercari.com")));
+    }
+
 }
 


### PR DESCRIPTION
To be matched, links need to begin with either http:// or https:// and contain more than 1 character after. 
ex. "Head to https://google.com for 50% off" --> https://google.com

Punctuation in sentence structure is also considered so the following cases are matched correctly:
ex. "Use my link at https://google.com, click on the search bar, and have fun" --> https://google.com
ex. "Google is a great search engine (go to https://google.com)!" --> https://google.com