### PR TITLE
Increase scope of regexs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,88 @@
 # PromoTube
+
+PromoTube is a webapp that allows users to easily find promo codes and affiliate links that go with their favorite creators or products.
+
+## Getting Started
+
+These instructions will get you a copy of the project up and running on your local machine for development and testing purposes. See deployment for notes on how to deploy the project on a live system.
+
+### Prerequisites
+
+What things you need to install the software and how to install them
+
+```
+run
+sudo apt install maven
+```
+
+### Installing
+
+A step by step series of examples that tell you how to get a development env running
+
+Say what the step will be
+
+```
+Give the example
+```
+
+And repeat
+
+```
+until finished
+```
+
+End with an example of getting some data out of the system or using it for a little demo
+
+## Running the tests
+
+Explain how to run the automated tests for this system
+
+### Break down into end to end tests
+
+Explain what these tests test and why
+
+```
+Give an example
+```
+
+### And coding style tests
+
+Explain what these tests test and why
+
+```
+Give an example
+```
+
+## Deployment
+
+Add additional notes about how to deploy this on a live system
+
+## Built With
+
+* [Dropwizard](http://www.dropwizard.io/1.0.2/docs/) - The web framework used
+* [Maven](https://maven.apache.org/) - Dependency Management
+* [ROME](https://rometools.github.io/rome/) - Used to generate RSS Feeds
+
+## Contributing
+
+Please read [CONTRIBUTING.md](https://gist.github.com/PurpleBooth/b24679402957c63ec426) for details on our code of conduct, and the process for submitting pull requests to us.
+
+## Versioning
+
+We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/your/project/tags). 
+
+## Authors
+
+* **Billie Thompson** - *Initial work* - [PurpleBooth](https://github.com/PurpleBooth)
+
+See also the list of [contributors](https://github.com/your/project/contributors) who participated in this project.
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details
+
+## Acknowledgments
+
+* Hat tip to anyone whose code was used
+* Inspiration
+* etc

--- a/src/main/java/com/google/step/youtube/DescriptionParser.java
+++ b/src/main/java/com/google/step/youtube/DescriptionParser.java
@@ -23,7 +23,7 @@ public class DescriptionParser {
     @VisibleForTesting
     enum Patterns {
 
-        CODE_NO_QUOTES(Pattern.compile("(?<=\\b(?i)code(?s).{1,2})([A-Z0-9]{2,})")),
+        CODE_NO_QUOTES(Pattern.compile("(?<=\\b(?i)code(?s).{1,2})([A-Z0-9][A-Za-z0-9\\-]+)")),
         CODE_WITH_QUOTES(Pattern.compile("(?<=\\b(?i)code(?s).{1,2}(\"|'))(.+?)(?=(\"|'))")),
         TO_AT_LINKS(Pattern.compile("(?<=\\b(?i)(to|at)(?s).{1,2})(https*:\\/\\/)[^\\s,\\)]+")),
         SYMBOL_NEAR_LINK(Pattern.compile(

--- a/src/main/java/com/google/step/youtube/DescriptionParser.java
+++ b/src/main/java/com/google/step/youtube/DescriptionParser.java
@@ -1,7 +1,6 @@
 package com.google.step.youtube;
 
 import com.google.common.annotations.VisibleForTesting;
-import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -24,9 +23,9 @@ public class DescriptionParser {
     @VisibleForTesting
     enum Patterns {
 
-        CODE_NO_QUOTES(Pattern.compile("(?<=\\b(?i)code\\s)([A-Z0-9]{2,})")),
-        CODE_WITH_QUOTES(Pattern.compile("(?<=\\b(?i)code\\s(\"|'))(.+?)(?=(\"|'))")),
-        TO_AT_LINKS(Pattern.compile("(?<=\\b(?i)(to|at)\\s)(https*:\\/\\/)[^\\s,\\)]+")),
+        CODE_NO_QUOTES(Pattern.compile("(?<=\\b(?i)code(?s).{1,2})([A-Z0-9]{2,})")),
+        CODE_WITH_QUOTES(Pattern.compile("(?<=\\b(?i)code(?s).{1,2}(\"|'))(.+?)(?=(\"|'))")),
+        TO_AT_LINKS(Pattern.compile("(?<=\\b(?i)(to|at)(?s).{1,2})(https*:\\/\\/)[^\\s,\\)]+")),
         SYMBOL_NEAR_LINK(Pattern.compile(
                 // check for link with $[0-9] or [0-9]% symbol <=100 chars before it
                   "((?<=(([0-9]%)|(\\$[0-9])).{1,100})(https*:\\/\\/)[^\\s,\\)]+)|"

--- a/src/test/java/com/google/step/youtube/DescriptionParserTest.java
+++ b/src/test/java/com/google/step/youtube/DescriptionParserTest.java
@@ -167,19 +167,19 @@ public final class DescriptionParserTest {
      */
 
     @Test
-    public void codeNoQuotes_lettersAndNumbers() {
+    public void codeNoQuotes_lettersNumbersHyphen() {
         String desc = "Get 10% off (save up to $44!) your own authentic Japanese snack box from "
-                + "Bokksu using my link: https://bit.ly/3fYbkZ5 and code FUNGBROS10";
+                + "Bokksu using my link: https://bit.ly/3fYbkZ5 and code FUNGBROS-10";
         List<OfferSnippet> actual = DescriptionParser.findMatches(CODE_NO_QUOTES_PATTERN, desc);
         
-        assertThat(extractPromoCodes(actual), equalTo(Arrays.asList("FUNGBROS10")));
+        assertThat(extractPromoCodes(actual), equalTo(Arrays.asList("FUNGBROS-10")));
     }
 
     @Test
     public void codeNoQuotes_promocodeCaseSensitive() {
-        String desc = "Use code LINUSsssS and get 25% off GlassWire at https://lmg.gg/glasswire";
+        String desc = "Use code LinusssS and get 25% off GlassWire at https://lmg.gg/glasswire";
         List<OfferSnippet> actual = DescriptionParser.findMatches(CODE_NO_QUOTES_PATTERN, desc);
-        assertThat(extractPromoCodes(actual), equalTo(Arrays.asList("LINUS")));
+        assertThat(extractPromoCodes(actual), equalTo(Arrays.asList("LinusssS")));
     }
 
     @Test

--- a/src/test/java/com/google/step/youtube/DescriptionParserTest.java
+++ b/src/test/java/com/google/step/youtube/DescriptionParserTest.java
@@ -206,9 +206,17 @@ public final class DescriptionParserTest {
     }
 
     @Test
-    public void codeNoQuotes_2Spaces() {
+    public void codeNoQuotes_ColonSpace() {
         String desc = "Get 20% off your first monthly box when you sign up at "
-                + "http://boxofawesome.com and enter the code  ROOSTER at checkout!";
+                + "http://boxofawesome.com and enter the code: ROOSTER at checkout!";
+        List<OfferSnippet> actual = DescriptionParser.findMatches(CODE_NO_QUOTES_PATTERN, desc);
+        assertThat(extractPromoCodes(actual), equalTo(Arrays.asList("ROOSTER")));
+    }
+
+    @Test
+    public void codeNoQuotes_3Spaces() {
+        String desc = "Get 20% off your first monthly box when you sign up at "
+                + "http://boxofawesome.com and enter the code   ROOSTER at checkout!";
         List<OfferSnippet> actual = DescriptionParser.findMatches(CODE_NO_QUOTES_PATTERN, desc);
         assertThat(extractPromoCodes(actual), equalTo(Collections.emptyList()));
     }
@@ -326,9 +334,17 @@ public final class DescriptionParserTest {
     }
 
     @Test
-    public void codeWithQuotes_2Spaces() {
+    public void codeWithQuotes_ColonSpace() {
         String desc = "Get %15 off Rhino Skin, Unparallel shoes and much more at "
-                + "https://darkventures.co.uk/shop with offer code  \"bobat15\"";
+                + "https://darkventures.co.uk/shop with offer code: \"bobat15\"";
+        List<OfferSnippet> actual = DescriptionParser.findMatches(CODE_WITH_QUOTES_PATTERN, desc);
+        assertThat(extractPromoCodes(actual), equalTo(Arrays.asList("bobat15")));
+    }
+
+    @Test
+    public void codeWithQuotes_3Spaces() {
+        String desc = "Get %15 off Rhino Skin, Unparallel shoes and much more at "
+                + "https://darkventures.co.uk/shop with offer code   \"bobat15\"";
         List<OfferSnippet> actual = DescriptionParser.findMatches(CODE_WITH_QUOTES_PATTERN, desc);
         assertThat(extractPromoCodes(actual), equalTo(Collections.emptyList()));
     }
@@ -497,8 +513,15 @@ public final class DescriptionParserTest {
     }
 
     @Test
-    public void toAtLinks_2SpacesBetween() {
-        String desc = "Use code LINUS and get 25% off GlassWire at  https://lmg.gg/glasswire";
+    public void toAtLinks_ColonSpace() {
+        String desc = "Use code LINUS and get 25% off GlassWire at: https://lmg.gg/glasswire";
+        List<OfferSnippet> actual = DescriptionParser.findMatches(TO_AT_LINKS_PATTERN, desc);
+        assertThat(extractPromoCodes(actual), equalTo(Arrays.asList("https://lmg.gg/glasswire")));
+    }
+
+    @Test
+    public void toAtLinks_3Spaces() {
+        String desc = "Use code LINUS and get 25% off GlassWire at   https://lmg.gg/glasswire";
         List<OfferSnippet> actual = DescriptionParser.findMatches(TO_AT_LINKS_PATTERN, desc);
         assertThat(extractPromoCodes(actual), equalTo(Collections.emptyList()));
     }


### PR DESCRIPTION
Unquoted promocodes are allowed to contain hyphens and only the first letter needs to be capitalized.

Promocodes and affiliate links appearing after keywords ("code", "to", "at") are allowed to have 1 or 2 chars in between. This is changed to allow for the following examples:
ex. "use code: 20OFF" and "use code 20OFF"